### PR TITLE
Move headsplugin-api module to HeadsPluginAPI repo

### DIFF
--- a/headsplugin-api/pom.xml
+++ b/headsplugin-api/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.github.cc007</groupId>
+    <artifactId>headsplugin-api</artifactId>
+    <version>2.1.0</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.20</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.bukkit</groupId>
+            <artifactId>bukkit</artifactId>
+            <version>1.13.2-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <version>5.3.7</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.14.1</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/HeadsPluginApi.java
+++ b/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/HeadsPluginApi.java
@@ -1,0 +1,83 @@
+package com.github.cc007.headsplugin.api;
+
+import com.github.cc007.headsplugin.api.business.services.heads.CategorySearcher;
+import com.github.cc007.headsplugin.api.business.services.heads.CategoryUpdater;
+import com.github.cc007.headsplugin.api.business.services.heads.HeadCreator;
+import com.github.cc007.headsplugin.api.business.services.heads.HeadPlacer;
+import com.github.cc007.headsplugin.api.business.services.heads.HeadSearcher;
+import com.github.cc007.headsplugin.api.business.services.heads.HeadToItemstackMapper;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.BeanFactory;
+
+import java.lang.reflect.InvocationTargetException;
+
+@RequiredArgsConstructor
+@Log4j2
+public class HeadsPluginApi {
+    private static HeadsPluginApi INSTANCE = null;
+
+    @Getter
+    private final BeanFactory beanFactory;
+
+    public static HeadsPluginApi getInstance(BeanFactory beanFactory) {
+        if (INSTANCE == null) {
+            INSTANCE = new HeadsPluginApi(beanFactory);
+        }
+        return INSTANCE;
+    }
+
+    public static void addSpringClassLoader(ClassLoader classLoader) {
+        try {
+            Class.forName("com.github.cc007.headsplugin.HeadsPlugin")
+                    .getMethod("addSpringClassLoader", ClassLoader.class).invoke(null, classLoader);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("HeadsPlugin class not found! Make sure that the HeadsPluginAPI plugin is in the plugins folder.", e);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException("Something is wrong with HeadsPluginAPI! Please contact the developer and provide the following stacktrace.", e);
+        }
+    }
+
+    public static HeadsPluginApi getInstance() {
+        if (INSTANCE == null) {
+            try {
+                BeanFactory beanFactory = null;
+                beanFactory = (BeanFactory) Class.forName("com.github.cc007.headsplugin.HeadsPlugin")
+                        .getMethod("getSpringContext").invoke(null);
+                INSTANCE = new HeadsPluginApi(beanFactory);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException("HeadsPlugin class not found! Make sure that the HeadsPluginAPI plugin is in the plugins folder.", e);
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                throw new RuntimeException("Something is wrong with HeadsPluginAPI! Please contact the developer and provide the following stacktrace.", e);
+            }
+        }
+        return INSTANCE;
+    }
+
+
+    public HeadToItemstackMapper getHeadToItemstackMapper() {
+        return beanFactory.getBean(HeadToItemstackMapper.class);
+    }
+
+    public HeadCreator getHeadCreator() {
+        return beanFactory.getBean(HeadCreator.class);
+    }
+
+    public HeadPlacer getHeadPlacer() {
+        return beanFactory.getBean(HeadPlacer.class);
+    }
+
+    public HeadSearcher getHeadSearcher() {
+        return beanFactory.getBean(HeadSearcher.class);
+    }
+
+    public CategoryUpdater getCategoryUpdater() {
+        return beanFactory.getBean(CategoryUpdater.class);
+    }
+
+    public CategorySearcher getCategorySearcher() {
+        return beanFactory.getBean(CategorySearcher.class);
+    }
+}

--- a/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/domain/Category.java
+++ b/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/domain/Category.java
@@ -1,0 +1,13 @@
+package com.github.cc007.headsplugin.api.business.domain;
+
+import lombok.Data;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+@Data
+@SuperBuilder
+public class Category {
+    private String name;
+    private List<String> sources;
+}

--- a/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/domain/CustomCategory.java
+++ b/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/domain/CustomCategory.java
@@ -1,0 +1,17 @@
+package com.github.cc007.headsplugin.api.business.domain;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+@Data
+@SuperBuilder
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class CustomCategory extends Category {
+
+    private List<String> searchTerms;
+}

--- a/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/domain/Head.java
+++ b/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/domain/Head.java
@@ -1,0 +1,27 @@
+package com.github.cc007.headsplugin.api.business.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.val;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Data
+@Builder
+public class Head {
+    private String name;
+    private String value;
+    private UUID headOwner;
+    private String headDatabase;
+
+    public Map<String, String> getAsMap() {
+        val map = new HashMap<String, String>();
+        map.put("name", name);
+        map.put("value", value);
+        map.put("headOwner", headOwner.toString());
+        map.put("headDatabase", headDatabase);
+        return map;
+    }
+}

--- a/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/services/heads/CategorySearcher.java
+++ b/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/services/heads/CategorySearcher.java
@@ -1,0 +1,32 @@
+package com.github.cc007.headsplugin.api.business.services.heads;
+
+import com.github.cc007.headsplugin.api.business.domain.Category;
+import com.github.cc007.headsplugin.api.business.domain.Head;
+
+import java.util.Set;
+
+public interface CategorySearcher {
+    /**
+     * get a set of all available categories
+     * @return the set of all available categories
+     */
+    Set<Category> getCategories();
+
+    /**
+     * get all heads from a certain category, based on the provided category name
+     *
+     * @param categoryName the name of the category to get heads from
+     * @return the set of all heads from the specified category
+     */
+    Set<Head> getCategoryHeads(String categoryName);
+
+    /**
+     * get all heads from a certain {@link Category}
+     *
+     * @param category the category to get heads from
+     * @return the set of all heads from the specified category
+     */
+    default Set<Head> getCategoryHeads(Category category) {
+        return getCategoryHeads(category.getName());
+    }
+}

--- a/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/services/heads/CategoryUpdater.java
+++ b/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/services/heads/CategoryUpdater.java
@@ -1,0 +1,32 @@
+package com.github.cc007.headsplugin.api.business.services.heads;
+
+import java.util.Collection;
+
+public interface CategoryUpdater {
+
+    /**
+     * Update the specified category
+     *
+     * @param categoryName the name of the category to update
+     * @throws IllegalArgumentException when an unknown category name is provided.
+     */
+    void updateCategory(String categoryName) throws IllegalArgumentException;
+
+    /**
+     * Update all categories.
+     */
+    void updateCategories();
+
+    /**
+     * Update all categories that haven't recently been updated. This depends on the property headsplugin.categories.update.interval in config.yml
+     */
+    void updateCategoriesIfNecessary();
+
+    /**
+     * Provides a list of updatable categories
+     *
+     * @param necessaryOnly return only the categories that are outside of the update interval
+     * @return the updatable categories
+     */
+    Collection<String> getUpdatableCategoryNames(boolean necessaryOnly);
+}

--- a/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/services/heads/HeadCreator.java
+++ b/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/services/heads/HeadCreator.java
@@ -1,0 +1,20 @@
+package com.github.cc007.headsplugin.api.business.services.heads;
+
+import com.github.cc007.headsplugin.api.business.domain.Head;
+
+import org.bukkit.entity.Player;
+
+import java.util.Map;
+
+public interface HeadCreator {
+    /**
+     * Create a head based on a skin from a given Player and head name.
+     * The head will also be stored in the local database.
+     * This method returns a map, because different head databases could give the head a different UUID
+     *
+     * @param player      the player who's skin will be used to create the head
+     * @param newHeadName the name of the newly created head
+     * @return the map of newly created heads (with database name as key)
+     */
+    Map<String, Head> createHead(Player player, String newHeadName);
+}

--- a/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/services/heads/HeadPlacer.java
+++ b/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/services/heads/HeadPlacer.java
@@ -1,0 +1,46 @@
+package com.github.cc007.headsplugin.api.business.services.heads;
+
+import com.github.cc007.headsplugin.api.business.domain.Head;
+
+import lombok.NonNull;
+import org.bukkit.Location;
+import org.bukkit.block.BlockFace;
+import org.bukkit.inventory.ItemStack;
+
+public interface HeadPlacer {
+    /**
+     * Place a head {@link ItemStack} at a certain {@link Location} in the world, with a certain rotation
+     *
+     * @param headItemStack the head itemstack to place in the world
+     * @param location the location where to place the head
+     * @param rotation the rotation of the head
+     */
+    void placeHead(@NonNull ItemStack headItemStack, @NonNull Location location, @NonNull BlockFace rotation);
+
+    /**
+     * Place a {@link Head} at a certain {@link Location} in the world, with a certain rotation
+     *
+     * @param head the head to place in the world
+     * @param location the location where to place the head
+     * @param rotation the rotation of the head
+     */
+    void placeHead(@NonNull Head head, @NonNull Location location, @NonNull BlockFace rotation);
+
+    /**
+     * Place a wall head {@link ItemStack} at a certain {@link Location} in the world, with a certain facing direction
+     *
+     * @param wallHeadItemStack the wall head itemstack to place in the world
+     * @param location the location where to place the wall head
+     * @param facing the facing direction of the wall head
+     */
+    void placeWallHead(@NonNull ItemStack wallHeadItemStack, @NonNull Location location, @NonNull BlockFace facing);
+
+    /**
+     * Place a {@link Head} at a certain {@link Location} in the world as wall head, with a certain facing direction
+     *
+     * @param head the head to place in the world
+     * @param location the location where to place the wall head
+     * @param facing the facing direction of the wall head
+     */
+    void placeWallHead(@NonNull Head head, @NonNull Location location, @NonNull BlockFace facing);
+}

--- a/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/services/heads/HeadSearcher.java
+++ b/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/services/heads/HeadSearcher.java
@@ -1,0 +1,31 @@
+package com.github.cc007.headsplugin.api.business.services.heads;
+
+import com.github.cc007.headsplugin.api.business.domain.Head;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface HeadSearcher {
+    /**
+     * Get the number of times a certain search term is used.
+     *
+     * @param searchTerm the search term
+     * @return the number of times the search term is used
+     */
+    int getSearchCount(String searchTerm);
+
+    /**
+     * Get the {@link Head} for the provided head owner {@link UUID}, as {@link Optional}
+     * @param headOwner the head owner UUID
+     * @return the optional head
+     */
+    Optional<Head> getHead(UUID headOwner);
+
+    /**
+     * Get all {@link Head}s based on a given search term
+     * @param searchTerm the search term
+     * @return the list of heads
+     */
+    List<Head> getHeads(String searchTerm);
+}

--- a/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/services/heads/HeadToItemstackMapper.java
+++ b/headsplugin-api/src/main/java/com/github/cc007/headsplugin/api/business/services/heads/HeadToItemstackMapper.java
@@ -1,0 +1,45 @@
+package com.github.cc007.headsplugin.api.business.services.heads;
+
+import com.github.cc007.headsplugin.api.business.domain.Head;
+
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+
+public interface HeadToItemstackMapper {
+    /**
+     * Get a list of {@link ItemStack}s, based on the provided list of {@link Head}s.
+     * The number of items per stack is set to 1.
+     *
+     * @param heads the list of heads
+     * @return the list of itemstacks
+     */
+    List<ItemStack> getItemStacks(List<Head> heads);
+
+    /**
+     * Get a list of {@link ItemStack}s, based on the provided list of {@link Head}s.
+     *
+     * @param heads the list of heads
+     * @param quantity the number of items per stack
+     * @return the list of itemstacks
+     */
+    List<ItemStack> getItemStacks(List<Head> heads, int quantity);
+
+    /**
+     * Get an {@link ItemStack}, based on the provided {@link Head}.
+     * The number of items per stack is set to 1.
+     *
+     * @param head the head
+     * @return the itemstack
+     */
+    ItemStack getItemStack(Head head);
+
+    /**
+     * Get an {@link ItemStack}, based on the provided {@link Head}.
+     *
+     * @param head the head
+     * @param quantity the number of items per stack
+     * @return the itemstack
+     */
+    ItemStack getItemStack(Head head, int quantity);
+}


### PR DESCRIPTION
It was impossible to use headsplugin-api as a dependency straight from github, because it was located in a private repository. While the project is private, the API should be public. The API is moved to the public HeadsPluginAPI repo for that reason.